### PR TITLE
Trying to fix crashes on large images by resize

### DIFF
--- a/fastapi/segmentation.py
+++ b/fastapi/segmentation.py
@@ -14,16 +14,19 @@ def get_segmentator():
     return model
 
 
-def get_segments(model, binary_image):
+def get_segments(model, binary_image, max_size=512):
 
     input_image = Image.open(io.BytesIO(binary_image)).convert("RGB")
+    width, height = input_image.size
+    resize_factor = min(max_size/width, max_size/height)
+    resized_image = input_image.resize((int(input_image.width*resize_factor), int(input_image.height*resize_factor)))
 
     preprocess = transforms.Compose([
         transforms.ToTensor(),
         transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
     ])
 
-    input_tensor = preprocess(input_image)
+    input_tensor = preprocess(resized_image)
     input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model
 
     with torch.no_grad():


### PR DESCRIPTION
The service would struggle working with images of large size, it makes sense to resize input to a target value as a preprocessing step before running the segmentation model.