### PR TITLE
no tempfiles saved and lib version bump

### DIFF
--- a/fastapi/requirements.txt
+++ b/fastapi/requirements.txt
@@ -1,4 +1,4 @@
-fastapi==0.58.0
+fastapi==0.58.1
 pillow==7.1.2
 torch==1.5.0+cpu
 torchvision==0.6.0+cpu

--- a/fastapi/server.py
+++ b/fastapi/server.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI, File
-import tempfile
-from starlette.responses import FileResponse
+from starlette.responses import Response
+import io
 from segmentation import get_segmentator, get_segments
 
 model = get_segmentator()
@@ -16,6 +16,6 @@ app = FastAPI(title="DeepLabV3 image segmentation",
 def get_segmentation_map(file: bytes = File(...)):
     '''Get segmentation maps from image file'''
     segmented_image = get_segments(model, file)
-    with tempfile.NamedTemporaryFile(mode="w+b", suffix=".png", delete=False) as outfile:
-        segmented_image.save(outfile)
-        return FileResponse(outfile.name, media_type="image/png")
+    bytes_io = io.BytesIO()
+    segmented_image.save(bytes_io, format='PNG')
+    return Response(bytes_io.getvalue(), media_type="image/png")

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,3 +1,3 @@
-streamlit==0.61.0 
+streamlit==0.62.1 
 requests==2.24.0
 requests-toolbelt==0.9.1


### PR DESCRIPTION
Avoid saving in the fastapi container unnecessary tempfiles (and as I am at it, bump up streamlit and fastapi versions).