### PR TITLE
Fix issues when running streamlit 

### DIFF
--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,3 +1,3 @@
-streamlit==0.86.0 
+streamlit==1.9.0 
 requests==2.24.0
 requests-toolbelt==0.9.1


### PR DESCRIPTION
It looks like bumping up streamlit requirements may solve https://github.com/davidefiocco/streamlit-fastapi-model-serving/issues/21 as older versions may be impacted by this problem https://stackoverflow.com/questions/61871050/filenotfounderror-errno-2-no-such-file-or-directory-sudo-sudo 

I tested this locally and seems a fix.