### PR TITLE
Fix altair and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To run the example in a machine running Docker and docker compose, run:
     docker compose build
     docker compose up
 
-To visit the FastAPI documentation of the resulting service, visit http://localhost:8000/ with a web browser.  
+To visit the FastAPI documentation of the resulting service, visit http://localhost:8000/docs with a web browser.  
 To visit the streamlit UI, visit http://localhost:8501.
 
 Logs can be inspected via:

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@ Simple example of usage of streamlit and FastAPI for ML model serving described 
 
 When developing simple APIs that serve machine learning models, it can be useful to have _both_ a backend (with API documentation) for other applications to call and a frontend for users to experiment with the functionality.
 
-In this example, we serve an [image semantic segmentation model](https://pytorch.org/hub/pytorch_vision_deeplabv3_resnet101/) using `FastAPI` for the backend service and `streamlit` for the frontend service. `docker-compose` orchestrates the two services and allows communication between them.
+In this example, we serve an [image semantic segmentation model](https://pytorch.org/hub/pytorch_vision_deeplabv3_resnet101/) using `FastAPI` for the backend service and `streamlit` for the frontend service. `docker compose` orchestrates the two services and allows communication between them.
 
-To run the example in a machine running Docker and docker-compose, run:
+To run the example in a machine running Docker and docker compose, run:
 
-    docker-compose build
-    docker-compose up
+    docker compose build
+    docker compose up
 
-To visit the FastAPI documentation of the resulting service, visit http://localhost:8000 with a web browser.  
+To visit the FastAPI documentation of the resulting service, visit http://localhost:8000/ with a web browser.  
 To visit the streamlit UI, visit http://localhost:8501.
 
 Logs can be inspected via:
 
-    docker-compose logs
+    docker compose logs
 
 ### Deployment
 

--- a/streamlit/requirements.txt
+++ b/streamlit/requirements.txt
@@ -1,3 +1,3 @@
-streamlit==1.10.0 
+streamlit==1.23.1
 requests==2.24.0
 requests-toolbelt==0.9.1


### PR DESCRIPTION
ciao @davidefiocco thanks for the great repo!

I just run it and found some minor issues:
- streamlit needs to be update otherwise it errors with module not found `altair.vegalit.v4`
- `docker-compose` is now deprecated in favor of `docker compose` https://www.docker.com/blog/new-docker-compose-v2-and-v1-deprecation/
- added `docs` to fastapi url in readme

I can split this PR if you want, but probably it would be an overkill.

I am adding a couple of screenshot here, maybe it could be nice to add them in the readme? I could do that in a follow up PR

![image](https://github.com/davidefiocco/streamlit-fastapi-model-serving/assets/132899327/c9aef9a2-9f68-455f-9058-f3cbfd8ceea9)

![image](https://github.com/davidefiocco/streamlit-fastapi-model-serving/assets/132899327/7b4084fc-38db-43c8-ac79-bfe6b8da564d)

